### PR TITLE
Fix: Cannot exit if no GPU detected

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # MGBench: Multi-GPU Computing Benchmark Suite
 # Copyright (c) 2016, Tal Ben-Nun
 # All rights reserved.
@@ -28,8 +28,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 NUMGPUS=`./build/numgpus`
-echo "Number of GPUs: ${NUMGPUS}"
-if [ $NUMGPUS -eq 0 ]
+echo "Number of GPUs: ${NUMGPUS:-0}"
+if [ ${NUMGPUS:-0} -eq 0 ]
 then
     echo "No GPUs found, aborting test."
     exit 0

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # MGBench: Multi-GPU Computing Benchmark Suite
 # Copyright (c) 2016, Tal Ben-Nun
 # All rights reserved.
@@ -28,8 +28,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 NUMGPUS=`./build/numgpus`
-echo "Number of GPUs: ${NUMGPUS:-0}"
-if [ ${NUMGPUS:-0} -eq 0 ]
+echo "Number of GPUs: ${NUMGPUS}"
+if [ $NUMGPUS -eq 0 ]
 then
     echo "No GPUs found, aborting test."
     exit 0

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@
 
 NUMGPUS=`./build/numgpus`
 echo "Number of GPUs: ${NUMGPUS}"
-if [ $NUMGPUS -eq 0 ]
+if [ $NUMGPUS -lt 1 ]
 then
     echo "No GPUs found, aborting test."
     exit 0

--- a/src/L0/numgpus.cpp
+++ b/src/L0/numgpus.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
 {
     int ndevs = 0;
     if (cudaGetDeviceCount(&ndevs) != cudaSuccess)
-        return 1;
+        ndevs = -1;
     printf("%d\n", ndevs);
-    return 0;
+    return ndevs == -1;
 }


### PR DESCRIPTION
When graphics are not configured correct, `./build/numgpus` returns nothing but with **exit code 1**. `run.sh` failed with

> Number of GPUs:
> ./run.sh: line 32: [: -eq: unary operator expected
> WARNING: nvidia-smi not found

This PR fixed above issue by giving a default value(0) to `$NUMGPUS`